### PR TITLE
retry policies change for http client

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -12,7 +12,7 @@
   },
   "RabbitMq": {
     "Hostname": "localhost",
-    "Port": 5672
+    "Port": 5673
   },
   "HackernewsApi": {
     "Url": "https://hacker-news.firebaseio.com/v0/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: rabbitmq:management-alpine
     hostname: rabbitmq
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "5673:5672"
+      - "15673:15672"
   mongo:
     image: mongo:latest
     container_name: mongodb


### PR DESCRIPTION
- made polly retries policy consistent with the global http client timeout to hopefully reduce / prevent service crashes [Polly docs on this use case](https://github.com/App-vNext/Polly/wiki/Polly-and-HttpClientFactory#use-case-applying-timeouts)
- changed rmq ports to avoid conflicts with the other service